### PR TITLE
Add local Docker image setup for development

### DIFF
--- a/docker-local/.gitignore
+++ b/docker-local/.gitignore
@@ -1,0 +1,1 @@
+github-mcp-server

--- a/docker-local/Dockerfile
+++ b/docker-local/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/github/github-mcp-server:latest
+
+# Copy our locally built executable and set permissions in one step
+COPY --chmod=755 github-mcp-server /server/github-mcp-server
+
+# The base image already has the correct ENTRYPOINT and CMD 

--- a/docker-local/README.md
+++ b/docker-local/README.md
@@ -1,0 +1,79 @@
+# Local GitHub MCP Server Docker Image
+
+This directory contains a Docker setup to build a local version of the GitHub MCP Server using the official image as a base and overriding it with your locally built executable.
+
+## Quick Start
+
+1. **Build the image:**
+   ```bash
+   ./build.sh
+   ```
+
+2. **Use the image:**
+   ```bash
+   docker run --rm -e GITHUB_PERSONAL_ACCESS_TOKEN=your_token github-mcp-server-local stdio
+   ```
+
+## Manual Build
+
+If you prefer to build manually:
+
+1. **Build the binary for Linux ARM64:**
+   ```bash
+   cd ..
+   GOOS=linux GOARCH=arm64 go build -o docker-local/github-mcp-server cmd/github-mcp-server/main.go
+   ```
+
+2. **Build the Docker image:**
+   ```bash
+   cd docker-local
+   docker build -t github-mcp-server-local .
+   ```
+
+## Usage
+
+The image works exactly like the official `ghcr.io/github/github-mcp-server` image, but uses your locally built binary instead.
+
+### Environment Variables
+
+- `GITHUB_PERSONAL_ACCESS_TOKEN`: Your GitHub Personal Access Token (required)
+
+### Example with VS Code
+
+Add this to your VS Code MCP configuration:
+
+```json
+{
+  "servers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "github-mcp-server-local"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "github_token",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}
+```
+
+## Advantages
+
+- **Fast builds**: Uses the official image as base, only rebuilds your local changes
+- **No build issues**: Avoids SSL certificate and dependency issues from building from scratch
+- **Consistent environment**: Uses the same runtime environment as the official image
+- **Easy updates**: Just rebuild the binary and Docker image when you make changes 

--- a/docker-local/build.sh
+++ b/docker-local/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Build script for local GitHub MCP Server Docker image
+
+set -e
+
+echo "Building local GitHub MCP Server binary..."
+cd ..
+GOOS=linux GOARCH=arm64 go build -o docker-local/github-mcp-server cmd/github-mcp-server/main.go
+
+echo "Building Docker image..."
+cd docker-local
+docker build -t github-mcp-server-local .
+
+echo "Docker image built successfully!"
+echo "You can now use it with:"
+echo "  docker run --rm -e GITHUB_PERSONAL_ACCESS_TOKEN=your_token github-mcp-server-local stdio" 


### PR DESCRIPTION
- Create docker-local/ directory with simplified Dockerfile
- Use official image as base and override with local binary
- Add build script for easy rebuilding
- Add documentation and usage examples
- Avoid SSL certificate issues by using official base image

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
