### PR TITLE
Add get_pull_request_threads tool for retrieving PR review threads with comment IDs

### DIFF
--- a/pkg/github/__toolsnaps__/get_pull_request_threads.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request_threads.snap
@@ -1,0 +1,34 @@
+{
+  "annotations": {
+    "title": "Get pull request review threads",
+    "readOnlyHint": true
+  },
+  "description": "Get review threads (discussions) for a specific pull request, including all comments in each thread with their IDs.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "unresolvedOnly": {
+        "description": "If true, only return unresolved threads",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_pull_request_threads"
+}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1818,3 +1818,122 @@ func newGQLIntPtr(i *int32) *githubv4.Int {
 	gi := githubv4.Int(*i)
 	return &gi
 }
+
+// GetPullRequestThreads creates a tool to get review threads (discussions) for a pull request.
+func GetPullRequestThreads(getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (mcp.Tool, server.ToolHandlerFunc) {
+	return mcp.NewTool("get_pull_request_threads",
+			mcp.WithDescription(t("TOOL_GET_PULL_REQUEST_THREADS_DESCRIPTION", "Get review threads (discussions) for a specific pull request, including all comments in each thread with their IDs.")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_GET_PULL_REQUEST_THREADS_USER_TITLE", "Get pull request review threads"),
+				ReadOnlyHint: ToBoolPtr(true),
+			}),
+			mcp.WithString("owner",
+				mcp.Required(),
+				mcp.Description("Repository owner"),
+			),
+			mcp.WithString("repo",
+				mcp.Required(),
+				mcp.Description("Repository name"),
+			),
+			mcp.WithNumber("pullNumber",
+				mcp.Required(),
+				mcp.Description("Pull request number"),
+			),
+			mcp.WithBoolean("unresolvedOnly",
+				mcp.Description("If true, only return unresolved threads"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var params struct {
+				Owner          string
+				Repo           string
+				PullNumber     int32
+				UnresolvedOnly *bool
+			}
+			if err := mapstructure.Decode(request.Params.Arguments, &params); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			client, err := getGQLClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get GitHub GQL client: %w", err)
+			}
+
+			var getPullRequestThreadsQuery struct {
+				Repository struct {
+					PullRequest struct {
+						ReviewThreads struct {
+							Nodes []struct {
+								ID                githubv4.ID                                 `json:"id"`
+								IsResolved        githubv4.Boolean                            `json:"isResolved"`
+								IsOutdated        githubv4.Boolean                            `json:"isOutdated"`
+								Line              *githubv4.Int                               `json:"line"`
+								OriginalLine      *githubv4.Int                               `json:"originalLine"`
+								StartLine         *githubv4.Int                               `json:"startLine"`
+								OriginalStartLine *githubv4.Int                               `json:"originalStartLine"`
+								DiffSide          githubv4.DiffSide                           `json:"diffSide"`
+								StartDiffSide     *githubv4.DiffSide                          `json:"startDiffSide"`
+								Path              githubv4.String                             `json:"path"`
+								SubjectType       githubv4.PullRequestReviewThreadSubjectType `json:"subjectType"`
+								Comments          struct {
+									Nodes []struct {
+										ID              githubv4.ID       `json:"id"`
+										Body            githubv4.String   `json:"body"`
+										CreatedAt       githubv4.DateTime `json:"createdAt"`
+										UpdatedAt       githubv4.DateTime `json:"updatedAt"`
+										MinimizedReason *githubv4.String  `json:"minimizedReason"`
+										IsMinimized     githubv4.Boolean  `json:"isMinimized"`
+										Author          struct {
+											Login githubv4.String `json:"login"`
+										} `json:"author"`
+										AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
+										URL               githubv4.URI                      `json:"url"`
+										DatabaseID        *githubv4.Int                     `json:"databaseId"`
+									} `json:"comments"`
+								} `graphql:"comments(first: 100)" json:"comments"`
+							} `json:"reviewThreads"`
+						} `graphql:"reviewThreads(first: 100)" json:"reviewThreads"`
+					} `graphql:"pullRequest(number: $prNum)" json:"pullRequest"`
+				} `graphql:"repository(owner: $owner, name: $repo)" json:"repository"`
+			}
+
+			vars := map[string]any{
+				"owner": githubv4.String(params.Owner),
+				"repo":  githubv4.String(params.Repo),
+				"prNum": githubv4.Int(params.PullNumber),
+			}
+
+			if err := client.Query(ctx, &getPullRequestThreadsQuery, vars); err != nil {
+				return ghErrors.NewGitHubGraphQLErrorResponse(ctx,
+					"failed to get pull request threads",
+					err,
+				), nil
+			}
+
+			threads := getPullRequestThreadsQuery.Repository.PullRequest.ReviewThreads.Nodes
+
+			// Filter for unresolved threads if requested
+			if params.UnresolvedOnly != nil && *params.UnresolvedOnly {
+				var unresolvedThreads []interface{}
+
+				for _, thread := range threads {
+					if !thread.IsResolved {
+						unresolvedThreads = append(unresolvedThreads, thread)
+					}
+				}
+
+				r, err := json.Marshal(unresolvedThreads)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal response: %w", err)
+				}
+				return mcp.NewToolResultText(string(r)), nil
+			}
+
+			r, err := json.Marshal(threads)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1888,7 +1888,7 @@ func GetPullRequestThreads(getGQLClient GetGQLClientFn, t translations.Translati
 										} `json:"author"`
 										AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
 										URL               githubv4.URI                      `json:"url"`
-										DatabaseID        *githubv4.Int                     `json:"databaseId"`
+										DatabaseID        *int64                            `json:"databaseId"`
 									} `json:"comments"`
 								} `graphql:"comments(first: 100)" json:"comments"`
 							} `json:"reviewThreads"`

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -2813,7 +2813,7 @@ func TestGetPullRequestThreads(t *testing.T) {
 												} `json:"author"`
 												AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
 												URL               githubv4.URI                      `json:"url"`
-												DatabaseID        *githubv4.Int                     `json:"databaseId"`
+												DatabaseID        *int64                            `json:"databaseId"`
 											} `json:"comments"`
 										} `graphql:"comments(first: 100)" json:"comments"`
 									} `json:"reviewThreads"`
@@ -2933,7 +2933,7 @@ func TestGetPullRequestThreads(t *testing.T) {
 												} `json:"author"`
 												AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
 												URL               githubv4.URI                      `json:"url"`
-												DatabaseID        *githubv4.Int                     `json:"databaseId"`
+												DatabaseID        *int64                            `json:"databaseId"`
 											} `json:"comments"`
 										} `graphql:"comments(first: 100)" json:"comments"`
 									} `json:"reviewThreads"`
@@ -3054,7 +3054,7 @@ func TestGetPullRequestThreads(t *testing.T) {
 												} `json:"author"`
 												AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
 												URL               githubv4.URI                      `json:"url"`
-												DatabaseID        *githubv4.Int                     `json:"databaseId"`
+												DatabaseID        *int64                            `json:"databaseId"`
 											} `json:"comments"`
 										} `graphql:"comments(first: 100)" json:"comments"`
 									} `json:"reviewThreads"`

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -2755,3 +2755,371 @@ func TestAddReplyToPullRequestComment(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPullRequestThreads(t *testing.T) {
+	t.Parallel()
+
+	// Verify tool definition once
+	mockClient := githubv4.NewClient(nil)
+	tool, _ := GetPullRequestThreads(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
+	assert.Equal(t, "get_pull_request_threads", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "repo")
+	assert.Contains(t, tool.InputSchema.Properties, "pullNumber")
+	assert.Contains(t, tool.InputSchema.Properties, "unresolvedOnly")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo", "pullNumber"})
+
+	tests := []struct {
+		name               string
+		mockedClient       *http.Client
+		requestArgs        map[string]any
+		expectToolError    bool
+		expectedToolErrMsg string
+		expectedThreads    int
+	}{
+		{
+			name: "successful threads retrieval",
+			mockedClient: githubv4mock.NewMockedHTTPClient(
+				githubv4mock.NewQueryMatcher(
+					struct {
+						Repository struct {
+							PullRequest struct {
+								ReviewThreads struct {
+									Nodes []struct {
+										ID                githubv4.ID                                 `json:"id"`
+										IsResolved        githubv4.Boolean                            `json:"isResolved"`
+										IsOutdated        githubv4.Boolean                            `json:"isOutdated"`
+										Line              *githubv4.Int                               `json:"line"`
+										OriginalLine      *githubv4.Int                               `json:"originalLine"`
+										StartLine         *githubv4.Int                               `json:"startLine"`
+										OriginalStartLine *githubv4.Int                               `json:"originalStartLine"`
+										DiffSide          githubv4.DiffSide                           `json:"diffSide"`
+										StartDiffSide     *githubv4.DiffSide                          `json:"startDiffSide"`
+										Path              githubv4.String                             `json:"path"`
+										SubjectType       githubv4.PullRequestReviewThreadSubjectType `json:"subjectType"`
+										Comments          struct {
+											Nodes []struct {
+												ID              githubv4.ID       `json:"id"`
+												Body            githubv4.String   `json:"body"`
+												CreatedAt       githubv4.DateTime `json:"createdAt"`
+												UpdatedAt       githubv4.DateTime `json:"updatedAt"`
+												MinimizedReason *githubv4.String  `json:"minimizedReason"`
+												IsMinimized     githubv4.Boolean  `json:"isMinimized"`
+												Author          struct {
+													Login githubv4.String `json:"login"`
+												} `json:"author"`
+												AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
+												URL               githubv4.URI                      `json:"url"`
+												DatabaseID        *githubv4.Int                     `json:"databaseId"`
+											} `json:"comments"`
+										} `graphql:"comments(first: 100)" json:"comments"`
+									} `json:"reviewThreads"`
+								} `graphql:"reviewThreads(first: 100)" json:"reviewThreads"`
+							} `graphql:"pullRequest(number: $prNum)" json:"pullRequest"`
+						} `graphql:"repository(owner: $owner, name: $repo)" json:"repository"`
+					}{},
+					map[string]any{
+						"owner": githubv4.String("owner"),
+						"repo":  githubv4.String("repo"),
+						"prNum": githubv4.Int(42),
+					},
+					githubv4mock.DataResponse(
+						map[string]any{
+							"repository": map[string]any{
+								"pullRequest": map[string]any{
+									"reviewThreads": map[string]any{
+										"nodes": []map[string]any{
+											{
+												"id":          "RT_kwDODKw3uc6WYN1T",
+												"isResolved":  true,
+												"isOutdated":  false,
+												"line":        10,
+												"path":        "src/main.go",
+												"subjectType": "LINE",
+												"diffSide":    "RIGHT",
+												"comments": map[string]any{
+													"nodes": []map[string]any{
+														{
+															"id":          "RC_kwDODKw3uc6WYN1T",
+															"body":        "This looks good!",
+															"createdAt":   "2023-01-01T00:00:00Z",
+															"updatedAt":   "2023-01-01T00:00:00Z",
+															"isMinimized": false,
+															"author": map[string]any{
+																"login": "reviewer1",
+															},
+															"authorAssociation": "COLLABORATOR",
+															"url":               "https://github.com/owner/repo/pull/42#discussion_r123",
+															"databaseId":        123,
+														},
+													},
+												},
+											},
+											{
+												"id":          "RT_kwDODKw3uc6WYN2T",
+												"isResolved":  false,
+												"isOutdated":  false,
+												"line":        20,
+												"path":        "src/utils.go",
+												"subjectType": "LINE",
+												"diffSide":    "RIGHT",
+												"comments": map[string]any{
+													"nodes": []map[string]any{
+														{
+															"id":          "RC_kwDODKw3uc6WYN2T",
+															"body":        "This needs improvement",
+															"createdAt":   "2023-01-01T01:00:00Z",
+															"updatedAt":   "2023-01-01T01:00:00Z",
+															"isMinimized": false,
+															"author": map[string]any{
+																"login": "reviewer2",
+															},
+															"authorAssociation": "MEMBER",
+															"url":               "https://github.com/owner/repo/pull/42#discussion_r124",
+															"databaseId":        124,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				),
+			),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(42),
+			},
+			expectToolError: false,
+			expectedThreads: 2,
+		},
+		{
+			name: "successful threads retrieval with unresolved filter",
+			mockedClient: githubv4mock.NewMockedHTTPClient(
+				githubv4mock.NewQueryMatcher(
+					struct {
+						Repository struct {
+							PullRequest struct {
+								ReviewThreads struct {
+									Nodes []struct {
+										ID                githubv4.ID                                 `json:"id"`
+										IsResolved        githubv4.Boolean                            `json:"isResolved"`
+										IsOutdated        githubv4.Boolean                            `json:"isOutdated"`
+										Line              *githubv4.Int                               `json:"line"`
+										OriginalLine      *githubv4.Int                               `json:"originalLine"`
+										StartLine         *githubv4.Int                               `json:"startLine"`
+										OriginalStartLine *githubv4.Int                               `json:"originalStartLine"`
+										DiffSide          githubv4.DiffSide                           `json:"diffSide"`
+										StartDiffSide     *githubv4.DiffSide                          `json:"startDiffSide"`
+										Path              githubv4.String                             `json:"path"`
+										SubjectType       githubv4.PullRequestReviewThreadSubjectType `json:"subjectType"`
+										Comments          struct {
+											Nodes []struct {
+												ID              githubv4.ID       `json:"id"`
+												Body            githubv4.String   `json:"body"`
+												CreatedAt       githubv4.DateTime `json:"createdAt"`
+												UpdatedAt       githubv4.DateTime `json:"updatedAt"`
+												MinimizedReason *githubv4.String  `json:"minimizedReason"`
+												IsMinimized     githubv4.Boolean  `json:"isMinimized"`
+												Author          struct {
+													Login githubv4.String `json:"login"`
+												} `json:"author"`
+												AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
+												URL               githubv4.URI                      `json:"url"`
+												DatabaseID        *githubv4.Int                     `json:"databaseId"`
+											} `json:"comments"`
+										} `graphql:"comments(first: 100)" json:"comments"`
+									} `json:"reviewThreads"`
+								} `graphql:"reviewThreads(first: 100)" json:"reviewThreads"`
+							} `graphql:"pullRequest(number: $prNum)" json:"pullRequest"`
+						} `graphql:"repository(owner: $owner, name: $repo)" json:"repository"`
+					}{},
+					map[string]any{
+						"owner": githubv4.String("owner"),
+						"repo":  githubv4.String("repo"),
+						"prNum": githubv4.Int(42),
+					},
+					githubv4mock.DataResponse(
+						map[string]any{
+							"repository": map[string]any{
+								"pullRequest": map[string]any{
+									"reviewThreads": map[string]any{
+										"nodes": []map[string]any{
+											{
+												"id":          "RT_kwDODKw3uc6WYN1T",
+												"isResolved":  true,
+												"isOutdated":  false,
+												"line":        10,
+												"path":        "src/main.go",
+												"subjectType": "LINE",
+												"diffSide":    "RIGHT",
+												"comments": map[string]any{
+													"nodes": []map[string]any{
+														{
+															"id":          "RC_kwDODKw3uc6WYN1T",
+															"body":        "This looks good!",
+															"createdAt":   "2023-01-01T00:00:00Z",
+															"updatedAt":   "2023-01-01T00:00:00Z",
+															"isMinimized": false,
+															"author": map[string]any{
+																"login": "reviewer1",
+															},
+															"authorAssociation": "COLLABORATOR",
+															"url":               "https://github.com/owner/repo/pull/42#discussion_r123",
+															"databaseId":        123,
+														},
+													},
+												},
+											},
+											{
+												"id":          "RT_kwDODKw3uc6WYN2T",
+												"isResolved":  false,
+												"isOutdated":  false,
+												"line":        20,
+												"path":        "src/utils.go",
+												"subjectType": "LINE",
+												"diffSide":    "RIGHT",
+												"comments": map[string]any{
+													"nodes": []map[string]any{
+														{
+															"id":          "RC_kwDODKw3uc6WYN2T",
+															"body":        "This needs improvement",
+															"createdAt":   "2023-01-01T01:00:00Z",
+															"updatedAt":   "2023-01-01T01:00:00Z",
+															"isMinimized": false,
+															"author": map[string]any{
+																"login": "reviewer2",
+															},
+															"authorAssociation": "MEMBER",
+															"url":               "https://github.com/owner/repo/pull/42#discussion_r124",
+															"databaseId":        124,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				),
+			),
+			requestArgs: map[string]any{
+				"owner":          "owner",
+				"repo":           "repo",
+				"pullNumber":     float64(42),
+				"unresolvedOnly": true,
+			},
+			expectToolError: false,
+			expectedThreads: 1, // Only unresolved threads
+		},
+		{
+			name: "failure to get pull request threads",
+			mockedClient: githubv4mock.NewMockedHTTPClient(
+				githubv4mock.NewQueryMatcher(
+					struct {
+						Repository struct {
+							PullRequest struct {
+								ReviewThreads struct {
+									Nodes []struct {
+										ID                githubv4.ID                                 `json:"id"`
+										IsResolved        githubv4.Boolean                            `json:"isResolved"`
+										IsOutdated        githubv4.Boolean                            `json:"isOutdated"`
+										Line              *githubv4.Int                               `json:"line"`
+										OriginalLine      *githubv4.Int                               `json:"originalLine"`
+										StartLine         *githubv4.Int                               `json:"startLine"`
+										OriginalStartLine *githubv4.Int                               `json:"originalStartLine"`
+										DiffSide          githubv4.DiffSide                           `json:"diffSide"`
+										StartDiffSide     *githubv4.DiffSide                          `json:"startDiffSide"`
+										Path              githubv4.String                             `json:"path"`
+										SubjectType       githubv4.PullRequestReviewThreadSubjectType `json:"subjectType"`
+										Comments          struct {
+											Nodes []struct {
+												ID              githubv4.ID       `json:"id"`
+												Body            githubv4.String   `json:"body"`
+												CreatedAt       githubv4.DateTime `json:"createdAt"`
+												UpdatedAt       githubv4.DateTime `json:"updatedAt"`
+												MinimizedReason *githubv4.String  `json:"minimizedReason"`
+												IsMinimized     githubv4.Boolean  `json:"isMinimized"`
+												Author          struct {
+													Login githubv4.String `json:"login"`
+												} `json:"author"`
+												AuthorAssociation githubv4.CommentAuthorAssociation `json:"authorAssociation"`
+												URL               githubv4.URI                      `json:"url"`
+												DatabaseID        *githubv4.Int                     `json:"databaseId"`
+											} `json:"comments"`
+										} `graphql:"comments(first: 100)" json:"comments"`
+									} `json:"reviewThreads"`
+								} `graphql:"reviewThreads(first: 100)" json:"reviewThreads"`
+							} `graphql:"pullRequest(number: $prNum)" json:"pullRequest"`
+						} `graphql:"repository(owner: $owner, name: $repo)" json:"repository"`
+					}{},
+					map[string]any{
+						"owner": githubv4.String("owner"),
+						"repo":  githubv4.String("repo"),
+						"prNum": githubv4.Int(42),
+					},
+					githubv4mock.ErrorResponse("expected test failure"),
+				),
+			),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(42),
+			},
+			expectToolError:    true,
+			expectedToolErrMsg: "expected test failure",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Setup client with mock
+			client := githubv4.NewClient(tc.mockedClient)
+			_, handler := GetPullRequestThreads(stubGetGQLClientFn(client), translations.NullTranslationHelper)
+
+			// Create call request
+			request := createMCPRequest(tc.requestArgs)
+
+			// Call handler
+			result, err := handler(context.Background(), request)
+			require.NoError(t, err)
+
+			textContent := getTextResult(t, result)
+
+			if tc.expectToolError {
+				require.True(t, result.IsError)
+				assert.Contains(t, textContent.Text, tc.expectedToolErrMsg)
+				return
+			}
+
+			// Parse the result and verify it's not an error
+			require.False(t, result.IsError)
+
+			// Parse the JSON response to check thread count
+			var threads []interface{}
+			err = json.Unmarshal([]byte(textContent.Text), &threads)
+			require.NoError(t, err)
+			assert.Len(t, threads, tc.expectedThreads)
+
+			// If we have threads, verify structure
+			if len(threads) > 0 {
+				threadMap := threads[0].(map[string]interface{})
+				assert.Contains(t, threadMap, "id")
+				assert.Contains(t, threadMap, "isResolved")
+				assert.Contains(t, threadMap, "path")
+				assert.Contains(t, threadMap, "comments")
+			}
+		})
+	}
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -78,6 +78,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 			toolsets.NewServerTool(GetPullRequestComments(getClient, t)),
 			toolsets.NewServerTool(GetPullRequestReviews(getClient, t)),
 			toolsets.NewServerTool(GetPullRequestDiff(getClient, t)),
+			toolsets.NewServerTool(GetPullRequestThreads(getGQLClient, t)),
 		).
 		AddWriteTools(
 			toolsets.NewServerTool(MergePullRequest(getClient, t)),


### PR DESCRIPTION
## Overview

Implements a new `get_pull_request_threads` tool to retrieve review threads (discussions) from pull requests, including all comment IDs as requested.

## What this PR adds

✅ **New Tool**: `get_pull_request_threads`
- Retrieves review threads/discussions for any pull request
- Includes all comments in each thread with their IDs (both GraphQL ID and Database ID)
- Supports filtering for unresolved threads only via `unresolvedOnly` parameter
- Returns comprehensive thread metadata: resolution status, file paths, line numbers, timestamps

✅ **GraphQL-based implementation**
- Uses GitHub GraphQL API for efficient nested data retrieval
- Properly handles large database IDs (fixed int64 overflow issue)
- Follows existing codebase patterns for GraphQL tools

✅ **Comprehensive testing**
- Full test coverage with GraphQL mocking
- Tests for successful retrieval, filtering, and error handling
- Real-world validation with live PR data

✅ **Production ready**
- Proper tool registration in pull_requests toolset
- Auto-generated toolsnap file for schema validation
- Read-only tool with appropriate annotations

## Parameters

- `owner` (required) - Repository owner
- `repo` (required) - Repository name  
- `pullNumber` (required) - Pull request number
- `unresolvedOnly` (optional) - If true, only returns unresolved threads

## Response includes

- Thread IDs and resolution status
- File paths and line numbers (including multi-line ranges)
- Comment IDs, bodies, timestamps, and author information
- Minimization status and author associations
- URLs for direct access to comments

## Bug fix included

- Fixed DatabaseID field type from `*githubv4.Int` to `*int64` to handle GitHub's large database IDs
- Prevents JSON unmarshaling errors with real PR data

## Testing

- ✅ Unit tests pass
- ✅ Integration tested with live GitHub data
- ✅ Filtering logic verified
- ✅ Tool appears correctly in MCP server tool list
- ✅ Successfully integrates with existing tools (tested with `add_reply_to_pull_request_comment`)

## Example usage

```json
{
  "name": "get_pull_request_threads",
  "arguments": {
    "owner": "github",
    "repo": "github-mcp-server", 
    "pullNumber": 123,
    "unresolvedOnly": true
  }
}
```

This tool enables users to efficiently discover and manage PR review discussions, making it easier to track unresolved feedback and maintain code review workflows.

## Commits

- `f0b3bfc` - Initial implementation with comprehensive tests
- `50a2e0d` - Fix DatabaseID type issue for large GitHub IDs